### PR TITLE
Colourise ip/journalctl commands

### DIFF
--- a/warhol.plugin.zsh
+++ b/warhol.plugin.zsh
@@ -65,6 +65,12 @@ if (( $+commands[grc] )); then
       }
     fi
 
+    if [ -x /usr/bin/journalctl ]; then
+      function journalctl(){
+        \grc --colour=auto /usr/bin/journalctl "$@"
+      }
+    fi
+
     if [ -x /sbin/ifconfig ]; then
       function ifconfig(){
         \grc --colour=auto /sbin/ifconfig "$@"


### PR DESCRIPTION
I noticed that `ifconfig` output was in colour on OS X but on Arch `ip` output wasn't.