### PR TITLE
Fix WARHOL_NO_ANSIVARS not being respected

### DIFF
--- a/warhol.plugin.zsh
+++ b/warhol.plugin.zsh
@@ -43,7 +43,7 @@ if (( $+commands[grc] )); then
   fi
 fi
 
-if [[ -z "WARHOL_NO_ANSIVARS" ]]; then
+if [[ -z "$WARHOL_NO_ANSIVARS" ]]; then
   # ANSI Color
   # Attributes are in #;#;#...;#
   # 0 reset, 1 bold, 4 underline, 5 flashing, 7 inverse


### PR DESCRIPTION
I guess this was just a small typo, but the comparison was missing the variable operator `$`. Hence, the ANSIVARS variables were never set.